### PR TITLE
Added executablePath for artisan

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "configuration": {
       "title": "Laravel Helper",
       "properties": {
+        "helper.executablePath": {
+          "type": "string",
+          "default": "php artisan",
+          "description": "Points to the Artisan executable"
+        },
         "helper.facades": {
           "type": "boolean",
           "default": true,

--- a/src/LaravelHelperExtension.ts
+++ b/src/LaravelHelperExtension.ts
@@ -19,6 +19,7 @@ class LaravelHelperExtension {
     const config = vscode.workspace.getConfiguration("helper");
 
     const extConfig: IConfig = {
+      executablePath: config.get("executablePath") ?? "php artisan",
       isFacade: config.get("facades") ?? true,
       isModel: config.get("models") ?? true,
       autoClearConsole: false,
@@ -109,7 +110,7 @@ class LaravelHelperExtension {
   private _getFacadeCommand(): ICommand {
     return {
       isEnabled: this._config.isFacade,
-      cmd: "php artisan ide-helper:generate",
+      cmd: `${this._config.executablePath} ide-helper:generate`,
       isAsync: false,
       match: "app",
     };
@@ -118,7 +119,7 @@ class LaravelHelperExtension {
   private _getModelCommand(): ICommand {
     return {
       isEnabled: this._config.isModel,
-      cmd: "php artisan ide-helper:models -n",
+      cmd: `${this._config.executablePath} ide-helper:models -n`,
       isAsync: false,
       match: "app(\\/models)?\\/(\\w|_)+.php$",
     };

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -40,6 +40,7 @@ suite("Extension Test Suite", () => {
 
   test("Default configuarion", () => {
     const config = vscode.workspace.getConfiguration("helper");
+    assert.strictEqual(config.get("executablePath"), "php artisan");
     assert.strictEqual(config.get("facades"), true);
     assert.strictEqual(config.get("models"), true);
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 interface IConfig {
+  executablePath: string;
   isFacade: boolean;
   isModel: boolean;
   autoClearConsole: boolean;


### PR DESCRIPTION
Solving two problems:
1. artisan is not always at the root of the project.
2. Sometimes php is accessible via a different path or installed only in a Docker container.

In the settings, you can specify your own setting for calling Artisan. For example: "`./bin/php artisan`" or "`docker-compose exec php php artisan`"