### PR TITLE
 fix: prevent triggering ide-helper commands on frontend components/assets containing "app"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "laravel-ide-helper",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "laravel-ide-helper",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -1441,7 +1441,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -2029,7 +2028,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3050,7 +3048,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5219,7 +5216,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6329,7 +6325,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/LaravelHelperExtension.ts
+++ b/src/LaravelHelperExtension.ts
@@ -308,7 +308,7 @@ class LaravelHelperExtension {
       isEnabled: this._config.isFacade,
       cmd: "php artisan ide-helper:generate",
       isAsync: false,
-      match: "app",
+      match: "\\/app\\/.*\\.php$",
     };
   }
 
@@ -317,7 +317,7 @@ class LaravelHelperExtension {
       isEnabled: this._config.isModel,
       cmd: "php artisan ide-helper:models -n",
       isAsync: false,
-      match: "app(\\/models)?\\/(\\w|_)+.php$",
+      match: "\\/app\\/(models\\/)?(\\w|_)+\\.php$",
     };
   }
 

--- a/src/test/suite/filePath.test.ts
+++ b/src/test/suite/filePath.test.ts
@@ -19,7 +19,7 @@ suite("FilePath Test Suite", () => {
     });
 
     test("should match model files in app/Models directory", () => {
-      const modelPattern = "app(\\/models)?\\/(\\w|_)+.php$";
+      const modelPattern = "\\/app\\/(models\\/)?(\\w|_)+\\.php$";
       
       const userModel = new FilePath("/project/app/Models/User.php");
       assert.strictEqual(userModel.isMatch(modelPattern), true);
@@ -29,15 +29,47 @@ suite("FilePath Test Suite", () => {
     });
 
     test("should match model files in app directory (legacy location)", () => {
-      const modelPattern = "app(\\/models)?\\/(\\w|_)+.php$";
+      const modelPattern = "\\/app\\/(models\\/)?(\\w|_)+\\.php$";
       const legacyModel = new FilePath("/project/app/User.php");
       assert.strictEqual(legacyModel.isMatch(modelPattern), true);
     });
 
     test("should not match non-PHP files", () => {
-      const modelPattern = "app(\\/models)?\\/(\\w|_)+.php$";
+      const modelPattern = "\\/app\\/(models\\/)?(\\w|_)+\\.php$";
       const jsFile = new FilePath("/project/app/Models/User.js");
       assert.strictEqual(jsFile.isMatch(modelPattern), false);
+    });
+
+    test("should handle Laravel facade pattern correctly", () => {
+      const facadePattern = "\\/app\\/.*\\.php$";
+
+      // Should match any PHP file in app/
+      assert.strictEqual(new FilePath("/project/app/Http/Controllers/UserController.php").isMatch(facadePattern), true);
+      assert.strictEqual(new FilePath("/project/app/Models/User.php").isMatch(facadePattern), true);
+      
+      // Should NOT match non-PHP files
+      assert.strictEqual(new FilePath("/project/app/Http/Controllers/UserController.js").isMatch(facadePattern), false);
+
+      // Should NOT match PHP files outside app/
+      assert.strictEqual(new FilePath("/project/resources/js/components/Appointment.php").isMatch(facadePattern), false);
+    });
+
+    test("should not match files inside resources/js/components or pages", () => {
+      const facadePattern = "\\/app\\/.*\\.php$";
+      const modelPattern = "\\/app\\/(models\\/)?(\\w|_)+\\.php$";
+
+      const vueComponent = new FilePath("/project/resources/js/components/App.vue");
+      const jsComponent = new FilePath("/project/resources/js/components/Appointment.js");
+      const vuePage = new FilePath("/project/resources/js/pages/SomePage.vue");
+
+      assert.strictEqual(vueComponent.isMatch(facadePattern), false);
+      assert.strictEqual(vueComponent.isMatch(modelPattern), false);
+
+      assert.strictEqual(jsComponent.isMatch(facadePattern), false);
+      assert.strictEqual(jsComponent.isMatch(modelPattern), false);
+
+      assert.strictEqual(vuePage.isMatch(facadePattern), false);
+      assert.strictEqual(vuePage.isMatch(modelPattern), false);
     });
 
     test("should handle empty pattern", () => {


### PR DESCRIPTION
 This PR fixes an issue where saving frontend assets (such as Vue/React components or scripts) containing `"app"` in their name or path (e.g., `App.vue`, `Appointment.js`, `AppHeader.vue` inside `resources/js/components/`) unnecessarily triggers the IDE Helper generation commands.

### Root Cause
Previously, the Facade command match pattern was set to a loose `"app"` substring. Because the save handler checks the absolute file path case-insensitively, any saved file containing `"app"` anywhere in its path would trigger the helper generator.
Files inside `resources/js/pages/` were generally unaffected as they are named after specific pages (e.g., `Welcome.vue`), but layout/common components under `resources/js/components/` frequently start with or contain the word `App`.

### Solution
1. **Refined Facade command pattern**: Changed `match: "app"` to `match: "\\/app\\/.*\\.php$"`. This ensures it only triggers on `.php` files under the `/app/` directory.
2. **Refined Model command pattern**: Tightened the pattern to `match: "\\/app\\/(models\\/)?(\\w|_)+\\.php$"` to avoid similar matching issues.
3. **Added Unit Tests**:
   - Updated existing test suite in `filePath.test.ts` to cover the new regex patterns.
   - Added assertions ensuring that frontend files containing `"app"` inside `resources/js/components/` and `resources/js/pages/` (such as `App.vue`, `Appointment.js`, `SomePage.
vue`) do not match either pattern.
### Testing
- Ran all tests locally via `npm test` and all 25 assertions passed successfully.